### PR TITLE
Feat: Add Support for Forwarded Discord Messages

### DIFF
--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -133,6 +133,29 @@ export async function getForumThreads(): Promise<DiscordThread[]> {
     }
 }
 
+interface MessageSnapshotFields {
+    content: string;
+    attachments: { url: string; content_type?: string }[];
+    embeds: unknown[];
+    timestamp: string;
+    edited_timestamp: string | null;
+    flags: number;
+    mentions: unknown[];
+    mention_roles: string[];
+    type: number;
+}
+
+interface MessageSnapshot {
+    message: MessageSnapshotFields;
+}
+
+interface MessageReference {
+    type?: number; // 0 = reply, 1 = forward
+    message_id?: string;
+    channel_id?: string;
+    guild_id?: string;
+}
+
 interface DiscordMessage {
     id: string;
     content: string;
@@ -141,6 +164,8 @@ interface DiscordMessage {
         username: string;
     };
     attachments: { url: string; content_type?: string }[];
+    message_reference?: MessageReference;
+    message_snapshots?: MessageSnapshot[];
 }
 
 export async function getDiscordMessage(

--- a/src/pages/api/stats.ts
+++ b/src/pages/api/stats.ts
@@ -448,17 +448,22 @@ async function computeStats(): Promise<StatsResponse> {
             const avatarUrl = `/api/avatar/${commit.user_id}.png`;
             const threadId = profileMap.get(commit.user_id) || "";
             const message = threadId ? await getDiscordMessage(threadId, commit.message_id) : null;
-            const rawMessageText = message?.content || "";
+
+            const isForwarded = message?.message_reference?.type === 1;
+            const forwardedMessage = isForwarded ? message?.message_snapshots?.[0]?.message : null;
+
+            const rawMessageText = forwardedMessage?.content || message?.content || "";
             const escaped = escapeDiscordSyntax(rawMessageText);
             const truncatedText = smartTruncate(escaped, 50);
             const sanitizedHtml = await markdownToHtml(truncatedText);
             const withDiscord = await restoreDiscordSyntax(sanitizedHtml);
             const messageHtml = parseGitLinks(withDiscord);
-            const attachments =
-                message?.attachments?.map((a) => ({
-                    url: a.url,
-                    type: a.content_type || "",
-                })) || [];
+
+            const rawAttachments = forwardedMessage?.attachments || message?.attachments || [];
+            const attachments = rawAttachments.map((a) => ({
+                url: a.url,
+                type: a.content_type || "",
+            }));
             return {
                 odId: commit.user_id,
                 username,


### PR DESCRIPTION
## Summary
- Add support for displaying forwarded Discord messages in commit overflow stats by handling message_reference and message_snapshots in API responses