### PR TITLE
fix: image button is larger than image

### DIFF
--- a/src/components/LiveFeed.tsx
+++ b/src/components/LiveFeed.tsx
@@ -519,8 +519,6 @@ export function LiveFeed() {
                                                                         maxHeight: "150px",
                                                                         width: "auto",
                                                                         height: "auto",
-                                                                        aspectRatio: "4 / 3",
-                                                                        objectFit: "cover",
                                                                         borderRadius: "4px",
                                                                         backgroundColor:
                                                                             "var(--border)",


### PR DESCRIPTION
Before:
<img width="1624" height="684" alt="image" src="https://github.com/user-attachments/assets/57e11cae-5c19-47d3-a1ea-f94881e0be3b" />

After:
<img width="1624" height="366" alt="image" src="https://github.com/user-attachments/assets/c4739656-8a26-430c-847b-32d745c1749a" />
