### PR TITLE
fix: reduce receipt cache TTL and add regenerate button

### DIFF
--- a/src/components/Receipt.tsx
+++ b/src/components/Receipt.tsx
@@ -73,7 +73,7 @@ export function Receipt({ discordUserId }: ReceiptProps) {
 
     const spinner = useSpinner(loadingDays.size > 0);
 
-    const fetchReceipt = useCallback(async () => {
+    const fetchReceipt = useCallback(async (regenerate = false) => {
         if (abortControllerRef.current) {
             abortControllerRef.current.abort();
         }
@@ -86,8 +86,10 @@ export function Receipt({ discordUserId }: ReceiptProps) {
         if (receiptType === "commits") {
             abortControllerRef.current = new AbortController();
             try {
+                const params = new URLSearchParams({ userId: discordUserId });
+                if (regenerate) params.set("regenerate", "true");
                 const response = await fetch(
-                    `/api/receipt/stream?userId=${discordUserId}`,
+                    `/api/receipt/stream?${params}`,
                     { signal: abortControllerRef.current.signal },
                 );
 
@@ -264,18 +266,28 @@ export function Receipt({ discordUserId }: ReceiptProps) {
 
             <div className="receipt-viewer">
                 <div className="receipt-toggle">
-                    <button
-                        className={`sort-btn ${receiptType === "summary" ? "active" : ""}`}
-                        onClick={() => setReceiptType("summary")}
-                    >
-                        [Summary]
-                    </button>
-                    <button
-                        className={`sort-btn ${receiptType === "commits" ? "active" : ""}`}
-                        onClick={() => setReceiptType("commits")}
-                    >
-                        [Full Log]
-                    </button>
+                    <div className="receipt-toggle-left">
+                        <button
+                            className={`sort-btn ${receiptType === "summary" ? "active" : ""}`}
+                            onClick={() => setReceiptType("summary")}
+                        >
+                            [Summary]
+                        </button>
+                        <button
+                            className={`sort-btn ${receiptType === "commits" ? "active" : ""}`}
+                            onClick={() => setReceiptType("commits")}
+                        >
+                            [Full Log]
+                        </button>
+                    </div>
+                    {receiptType === "commits" && !loading && !streaming && !error && receiptData && (
+                        <button
+                            className="sort-btn"
+                            onClick={() => fetchReceipt(true)}
+                        >
+                            [Regenerate]
+                        </button>
+                    )}
                 </div>
 
             {loading ? (
@@ -285,7 +297,7 @@ export function Receipt({ discordUserId }: ReceiptProps) {
                     <pre style={{ color: "var(--error, #ff6b6b)" }}>
                         Error: {error}{" "}
                         <button
-                            onClick={fetchReceipt}
+                            onClick={() => fetchReceipt()}
                             style={{
                                 background: "none",
                                 border: "none",

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -13,7 +13,7 @@ export const TTL = {
     DISCORD_CHANNEL: 86400, // 24 hours
     DISCORD_ROLE: 86400, // 24 hours
     FORUM_THREADS: 3600, // 1 hour - updates more frequently
-    COMMIT_SUMMARY: 604800, // 7 days - summaries don't change
+    COMMIT_SUMMARY: 86400, // 1 day
 } as const;
 
 export async function cacheGet<T>(key: string): Promise<T | null> {
@@ -25,6 +25,17 @@ export async function cacheSet<T>(key: string, value: T, ttlSeconds?: number): P
         await redis.set(key, value, { ex: ttlSeconds });
     } else {
         await redis.set(key, value);
+    }
+}
+
+export async function cacheDel(key: string): Promise<void> {
+    await redis.del(key);
+}
+
+export async function cacheDelPattern(pattern: string): Promise<void> {
+    const keys = await redis.keys(pattern);
+    if (keys.length > 0) {
+        await redis.del(...keys);
     }
 }
 

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -33,10 +33,15 @@ export async function cacheDel(key: string): Promise<void> {
 }
 
 export async function cacheDelPattern(pattern: string): Promise<void> {
-    const keys = await redis.keys(pattern);
-    if (keys.length > 0) {
-        await redis.del(...keys);
-    }
+    let cursor = "0";
+    do {
+        const result = await redis.scan(Number(cursor), { match: pattern, count: 100 });
+        const [nextCursor, keys] = result as [string, string[]];
+        if (keys.length > 0) {
+            await redis.del(...keys);
+        }
+        cursor = String(nextCursor);
+    } while (cursor !== "0");
 }
 
 export async function cached<T>(

--- a/src/pages/api/receipt/stream.ts
+++ b/src/pages/api/receipt/stream.ts
@@ -6,7 +6,7 @@ import {
 import { getDiscordMessage } from "../../../lib/discord";
 import { summarizeCommitMessage } from "../../../lib/groq";
 import { queryD1 } from "../../../lib/d1";
-import { cacheGet, cacheSet, TTL } from "../../../lib/redis";
+import { cacheGet, cacheSet, cacheDelPattern, TTL } from "../../../lib/redis";
 
 interface DaySummaryCache {
     summaries: Map<number, string | null>;
@@ -35,6 +35,7 @@ async function resolveUserId(userId: string | null, username: string | null): Pr
 }
 
 export const GET: APIRoute = async ({ url }) => {
+    const regenerate = url.searchParams.get("regenerate") === "true";
     const userId = await resolveUserId(
         url.searchParams.get("userId"),
         url.searchParams.get("user"),
@@ -57,6 +58,10 @@ export const GET: APIRoute = async ({ url }) => {
                     `data: ${JSON.stringify({ type: "init", receipt: receiptData.baseReceipt })}\n\n`,
                 ),
             );
+
+            if (regenerate) {
+                await cacheDelPattern(`receipt:day:${userId}:*`);
+            }
 
             if (receiptData.commits.length === 0 || !receiptData.threadId) {
                 controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`));

--- a/src/pages/api/receipt/stream.ts
+++ b/src/pages/api/receipt/stream.ts
@@ -59,14 +59,14 @@ export const GET: APIRoute = async ({ url }) => {
                 ),
             );
 
-            if (regenerate) {
-                await cacheDelPattern(`receipt:day:${userId}:*`);
-            }
-
             if (receiptData.commits.length === 0 || !receiptData.threadId) {
                 controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`));
                 controller.close();
                 return;
+            }
+
+            if (regenerate) {
+                await cacheDelPattern(`receipt:day:${userId}:*`);
             }
 
             const commitsByDay = new Map<string, typeof receiptData.commits>();

--- a/src/pages/receipt.astro
+++ b/src/pages/receipt.astro
@@ -81,9 +81,14 @@ if (devUserOverride) {
 
     .receipt-page :global(.receipt-toggle) {
         display: flex;
-        justify-content: flex-end;
-        gap: 0.5ch;
+        justify-content: space-between;
+        align-items: center;
         margin-bottom: 1rem;
+    }
+
+    .receipt-page :global(.receipt-toggle-left) {
+        display: flex;
+        gap: 0.5ch;
     }
 
     .receipt-page :global(.receipt) {


### PR DESCRIPTION
## Summary
- Reduce `COMMIT_SUMMARY` cache TTL from 7 days to 1 day for less aggressive caching
- Add `cacheDel` and `cacheDelPattern` helpers to Redis utils
- Add a `[Regenerate]` button to the commits receipt that clears cached summaries and re-streams fresh ones
- Button only appears when the receipt is fully generated

## Test plan
- [ ] Verify receipt loads normally with cached summaries
- [ ] Click [Regenerate] and confirm summaries are re-generated from scratch
- [ ] Confirm the button only appears after streaming completes
- [ ] Verify summary tab does not show the regenerate button

Generated with [Ami](https://ami.dev)